### PR TITLE
Modified setup_beacon.sh script to be compatible with Honister

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -5,28 +5,33 @@ BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS = " \
-  ##OEROOT##/meta \
-  ##OEROOT##/meta-poky \
-  ##OEROOT##/../meta-openembedded/meta-oe \
-  ##OEROOT##/../meta-openembedded/meta-multimedia \
-  ##OEROOT##/../meta-openembedded/meta-python \
-  ##OEROOT##/../meta-beacon-nxp \
-  ##OEROOT##/../meta-beacon-common \
-  ##OEROOT##/../meta-freescale \
-  ##OEROOT##/../meta-freescale-3rdparty \
-  ##OEROOT##/../meta-freescale-distro \
-  ##OEROOT##/../meta-imx/meta-bsp \
-  ##OEROOT##/../meta-imx/meta-sdk \
-  ##OEROOT##/../meta-imx/meta-ml \
-  ##OEROOT##/../meta-imx/meta-v2x \
-  ##OEROOT##/../meta-nxp-demo-experience \
-  ##OEROOT##/../meta-browser/meta-chromium \
-  ##OEROOT##/../meta-clang \
-  ##OEROOT##/../meta-openembedded/meta-gnome \
-  ##OEROOT##/../meta-openembedded/meta-networking \
-  ##OEROOT##/../meta-openembedded/meta-filesystems \
-  ##OEROOT##/../meta-qt5\
-  ##OEROOT##/../meta-python2 \
-  "
-  
+  ${BSPDIR}/sources/poky/meta \
+  ${BSPDIR}/sources/poky/meta-poky \
+  \
+  ${BSPDIR}/sources/meta-openembedded/meta-oe \
+  ${BSPDIR}/sources/meta-openembedded/meta-multimedia \
+  ${BSPDIR}/sources/meta-openembedded/meta-python \
+  \
+  ${BSPDIR}/sources/meta-freescale \
+  ${BSPDIR}/sources/meta-freescale-3rdparty \
+  ${BSPDIR}/sources/meta-freescale-distro \
+"
+
+# i.MX Yocto Project Release layers
+BBLAYERS += "${BSPDIR}/sources/meta-imx/meta-bsp"
+BBLAYERS += "${BSPDIR}/sources/meta-imx/meta-sdk"
+BBLAYERS += "${BSPDIR}/sources/meta-imx/meta-ml"
+BBLAYERS += "${BSPDIR}/sources/meta-imx/meta-v2x"
+BBLAYERS += "${BSPDIR}/sources/meta-nxp-demo-experience"
+
+BBLAYERS += "${BSPDIR}/sources/meta-browser/meta-chromium"
+BBLAYERS += "${BSPDIR}/sources/meta-clang"
+BBLAYERS += "${BSPDIR}/sources/meta-openembedded/meta-gnome"
+BBLAYERS += "${BSPDIR}/sources/meta-openembedded/meta-networking"
+BBLAYERS += "${BSPDIR}/sources/meta-openembedded/meta-filesystems"
+BBLAYERS += "${BSPDIR}/sources/meta-qt6"
+BBLAYERS += "${BSPDIR}/sources/meta-python2"
+BBLAYERS += "${BSPDIR}/sources/meta-virtualization"
+BBLAYERS += "${BSPDIR}/sources/meta-beacon-nxp"
+BBLAYERS += "${BSPDIR}/sources/meta-beacon-common"
 

--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -1,10 +1,11 @@
-# This builds the iMX8M Plus by default 
-MACHINE ??= 'imx8mp-beacon-kit'
+
+MACHINE ??= "imx8mp-beacon-kit"
+
 
 DISTRO ?= 'fsl-imx-xwayland'
-PACKAGE_CLASSES ?= 'package_rpm'
+PACKAGE_CLASSES ?= "package_rpm"
 EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
-USER_CLASSES ?= "buildstats image-mklibs image-prelink"
+USER_CLASSES ?= "buildstats"
 PATCHRESOLVE = "noop"
 BB_DISKMON_DIRS ??= "\
     STOPTASKS,${TMPDIR},1G,100K \
@@ -15,18 +16,12 @@ BB_DISKMON_DIRS ??= "\
     ABORT,${DL_DIR},100M,1K \
     ABORT,${SSTATE_DIR},100M,1K \
     ABORT,/tmp,10M,1K"
-PACKAGECONFIG_append_pn-qemu-system-native = " sdl"
-PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
-CONF_VERSION = "1"
+PACKAGECONFIG:append:pn-qemu-system-native = " sdl"
+CONF_VERSION = "2"
 
 DL_DIR="/home/beacon/beacon/yocto-cache/download"
 SSTATE_DIR="/home/beacon/beacon/yocto-cache/sstate-cache"
-INTERNAL_MIRROR = "http://localhost"
 
 # Switch to Debian packaging and include package-management in the image
 PACKAGE_CLASSES = "package_deb"
 EXTRA_IMAGE_FEATURES += "package-management"
-
-
-
-

--- a/laird_hack.sh
+++ b/laird_hack.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# This is a hack to copy laird firmware files download from the laird github repository
-# otherwise it has to be copied manually and breaks the build if its missing
-#
-
-CWD=`pwd`
-wget -O $CWD/../release/laird-lwb5-fcc-firmware-7.0.0.326.tar.bz2 "https://github.com/LairdCP/Sterling-LWB-and-LWB5-Release-Packages/releases/download/LRD-REL-7.0.0.326/laird-lwb5-fcc-firmware-7.0.0.326.tar.bz2"

--- a/setup_beacon.sh
+++ b/setup_beacon.sh
@@ -103,8 +103,4 @@ fi
 #to verify a build directory already exists
 cp $CWD/../sources/meta-beacon-nxp/conf/local.conf.sample $CWD/conf/local.conf.sample
 
-#this is a hack to copy Laird firmware to release directory
-
-sh $CWD/../sources/meta-beacon-nxp/laird_hack.sh
-
 clean_up


### PR DESCRIPTION
The meta-beacon-nxp layer needed to be updated so that the setup
scripts were compatible with Honister builds

Signed-off-by: Richard Feliciano <RFeliciano@BeaconEmbedded.com>