### PR TITLE
Added machine conf for iMX8M 4GB support

### DIFF
--- a/conf/machine/beacon-imx8mm-4g-kit.conf
+++ b/conf/machine/beacon-imx8mm-4g-kit.conf
@@ -1,0 +1,24 @@
+#@TYPE: Machine
+#@NAME: NXP i.MX 8M Mini EVK with LPDDR4
+#@SOC: i.MX8MM
+#@DESCRIPTION: Machine configuration for NXP i.MX 8M Mini Evaluation Kit with LPDDR4
+#@MAINTAINER: Jun Zhu <junzhu@nxp.com>
+#@MAINTAINER: Richard Feliciano <richard.feliciano@beaconembedded.com>
+
+require include/beacon-imx8mm-4gb-kit.inc
+
+
+# Device tree for Beacon EmbeddedWorks i.MX8MM Kit
+KERNEL_DEVICETREE_BASENAME = "imx8mm-beacon"
+KERNEL_DEVICETREE:append:use-nxp-bsp = " \
+	freescale/${KERNEL_DEVICETREE_BASENAME}-kit.dtb \
+"
+
+DDR_FIRMWARE_NAME = " \
+	lpddr4_pmu_train_1d_imem.bin \
+	lpddr4_pmu_train_1d_dmem.bin \
+	lpddr4_pmu_train_2d_imem.bin \
+	lpddr4_pmu_train_2d_dmem.bin \
+"
+
+IMXBOOT_TARGETS_BASENAME = "flash_evk"

--- a/conf/machine/include/beacon-imx8mm-4gb-kit.inc
+++ b/conf/machine/include/beacon-imx8mm-4gb-kit.inc
@@ -1,0 +1,39 @@
+MACHINEOVERRIDES =. "imx-boot-container:mx8:mx8m:mx8mm:"
+
+require conf/machine/include/imx-base.inc
+require conf/machine/include/arm/armv8a/tune-cortexa53.inc
+
+MACHINE_FEATURES += "pci wifi bluetooth optee"
+
+UBOOT_DTB_NAME = "${KERNEL_DEVICETREE_BASENAME}-kit.dtb"
+
+IMX_DEFAULT_BOOTLOADER_use-nxp-bsp = "u-boot-imx"
+IMX_DEFAULT_BOOTLOADER_use-mainline-bsp = "u-boot-fslc"
+
+UBOOT_SUFFIX = "bin"
+
+UBOOT_CONFIG ??= "sd"
+UBOOT_CONFIG[sd] = "imx8mm_4g_beacon_defconfig,sdcard"
+#UBOOT_CONFIG[fspi] = "beacon_imx8mm_fspi_defconfig"
+SPL_BINARY = "spl/u-boot-spl.bin"
+
+ATF_PLATFORM = "imx8mm"
+ATF_LOAD_ADDR = "0x920000"
+
+# Extra firmware package name, that is required to build boot container for fslc bsp
+IMX_EXTRA_FIRMWARE = "firmware-imx-8m"
+
+IMXBOOT_TARGETS = "${@bb.utils.contains('UBOOT_CONFIG', 'fspi', '${IMXBOOT_TARGETS_BASENAME}_flexspi', '${IMXBOOT_TARGETS_BASENAME}', d)}"
+
+IMX_BOOT_SOC_TARGET = "iMX8MM"
+
+SERIAL_CONSOLES = "115200;ttymxc1"
+
+LOADADDR = ""
+UBOOT_SUFFIX = "bin"
+UBOOT_MAKE_TARGET = "all"
+IMX_BOOT_SEEK = "33"
+
+OPTEE_BIN_EXT = "8mm"
+TEE_LOAD_ADDR = "0xbe000000"
+


### PR DESCRIPTION
Added support to build an iMX8M Mini image to use 4GB Ram

Signed-off-by: Richard Feliciano <RFeliciano@BeaconEmbedded.com>