### PR TITLE
Modified the beacon-imx8mm-4g-kit so it does not build optee

### DIFF
--- a/conf/machine/include/beacon-imx8mm-4gb-kit.inc
+++ b/conf/machine/include/beacon-imx8mm-4gb-kit.inc
@@ -3,7 +3,7 @@ MACHINEOVERRIDES =. "imx-boot-container:mx8:mx8m:mx8mm:"
 require conf/machine/include/imx-base.inc
 require conf/machine/include/arm/armv8a/tune-cortexa53.inc
 
-MACHINE_FEATURES += "pci wifi bluetooth optee"
+MACHINE_FEATURES += "pci wifi bluetooth"
 
 UBOOT_DTB_NAME = "${KERNEL_DEVICETREE_BASENAME}-kit.dtb"
 


### PR DESCRIPTION
The Uboot for the iMX8M Mini 4GB platform crashes if optee is
enabled for the build.  So modified the machine conf to prevent
it from being built and added to the uboot flash.bin image

Signed-off-by: Richard Feliciano <RFeliciano@BeaconEmbedded.com>